### PR TITLE
Correct npm module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-photoswipe",
   "version": "1.1.0",
   "description": "PhotoSwipe, PhotoSwipeGallery component for ReactJS base on PhotoSwipe.",
-  "main": "lib/index.js",
+  "main": "dist/react-photoswipe.js",
   "scripts": {
     "start": "NODE_ENV=development gulp start",
     "build": "NODE_ENV=production gulp build"


### PR DESCRIPTION
Currently when importing 

`import { PhotoSwipeGallery } from 'react-photoswipe';`

with webpack it yields an error

```
 ./~/react-photoswipe/src/photoswipe.js
[0] Module parse failed: ...../node_modules/react-photoswipe/src/photoswipe.js Unexpected token (9:19)
[0] You may need an appropriate loader to handle this file type.
```

With the pull request, it fixes the issue and make imports work.
And I also assume that is what the dist folder is for, to export and expose the final built file