### PR TITLE
Updates for React 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "node-sass": "^3.4.2",
     "opn": "^4.0.0",
     "postcss-loader": "^0.8.0",
+    "prop-types": "^15.5.8",
     "react-router": "^2.0.0",
     "react-transform-hmr": "^1.0.1",
     "run-sequence": "^1.1.5",

--- a/src/PhotoSwipe.js
+++ b/src/PhotoSwipe.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Photoswipe from 'photoswipe';
 import PhotoswipeUIDefault from 'photoswipe/dist/photoswipe-ui-default';
@@ -7,12 +8,12 @@ import events from './events';
 
 class PhotoSwipe extends React.Component {
   static propTypes = {
-    isOpen: React.PropTypes.bool.isRequired,
-    items: React.PropTypes.array.isRequired,
-    options: React.PropTypes.object,
-    onClose: React.PropTypes.func,
-    id: React.PropTypes.string,
-    className: React.PropTypes.string
+    isOpen: PropTypes.bool.isRequired,
+    items: PropTypes.array.isRequired,
+    options: PropTypes.object,
+    onClose: PropTypes.func,
+    id: PropTypes.string,
+    className: PropTypes.string
   };
   static defaultProps = {
     items: [],

--- a/src/PhotoSwipeGallery.js
+++ b/src/PhotoSwipeGallery.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import PhotoSwipe from './PhotoSwipe.js';
 import pick from 'lodash.pick';
@@ -7,11 +8,11 @@ import classnames from 'classnames';
 
 class PhotoSwipeGallery extends React.Component {
   static propTypes = {
-    items: React.PropTypes.array.isRequired,
-    options: React.PropTypes.object,
-    thumbnailContent: React.PropTypes.func,
-    id: React.PropTypes.string,
-    className: React.PropTypes.string
+    items: PropTypes.array.isRequired,
+    options: PropTypes.object,
+    thumbnailContent: PropTypes.func,
+    id: PropTypes.string,
+    className: PropTypes.string
   };
 
   static defaultProps = {


### PR DESCRIPTION
Uses the [prop-types](https://github.com/reactjs/prop-types) library instead of accessing PropTypes from the main React package. This avoids deprecation warnings in React 15.5.